### PR TITLE
Auto opening HTTPS 443 port

### DIFF
--- a/sple.sh
+++ b/sple.sh
@@ -56,9 +56,15 @@ then
     le=$(dpkg-query -W -f='${Status}' letsencrypt 2>/dev/null | grep -c "ok installed")
     
     if [ $le == 0 ]
-    then 
-        sudo apt-get update
-        sudo apt-get install letsencrypt -y
+    then
+        echo "Let's Encrypt is not installed/found. Would you like to continue to install it?"
+        read -p "Y or N" -n 1 -r
+        echo ""
+        if [[ "$REPLY" =~ ^[Yy]$ ]]
+        then
+            sudo apt-get update
+            sudo apt-get install letsencrypt -y
+        fi 
     fi
 fi
 

--- a/sple.sh
+++ b/sple.sh
@@ -191,7 +191,8 @@ echo "}" | sudo tee -a $configfile
 # Wrapping it up
 echo ""
 echo ""
-echo "We're almost done here. Restarting nginx..."
+echo "We're almost done here. Opening HTTPS Port and  Restarting nginx..."
+sudo ufw allow https
 sudo service nginx-sp restart
 echo ""
 echo ""


### PR DESCRIPTION
Hi, thanks for the useful script! 

I noticed that after the script has run, port 443 does not get automatically opened (on my Ubuntu 16 droplet it didn't anyway). I used the UFW firewall command to open this up prior to nginx being restart. 

See amends 👍 