### PR TITLE
Update Ubuntu 16.04 cron information

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add the following to your crontab (`crontab -e`)
 
 **For Ubuntu 16.04**  
 ```
-0 */12 * * * letsencrypt renew --post-hook "service nginx-sp reload"
+0 */12 * * * letsencrypt renew
 ```
 
 ## Notes


### PR DESCRIPTION
Removed the --post-hook following renewal as this is not supported in the version of LetsEncrypt which this script installs.